### PR TITLE
Fix unwanted scroll-to-top behavior on click of figure export buttons

### DIFF
--- a/public/comparison.html
+++ b/public/comparison.html
@@ -263,7 +263,7 @@
                     <!-- Graph 1 -->
                     <div class="mx-auto w-full">
                         <div id="contributor-1"  style="display: none" class="flex-col items-center w-full my-3">                
-                            <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+                            <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                                 <figure class="highcharts-figure" onclick="return false;">
                                     <div id="cont-1"></div>
                                     <!-- JS file link -->
@@ -274,7 +274,7 @@
                         </div>
                 
                         <div id="commit-1" style="display: none" class="flex-col items-center my-3 w-full">
-                            <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+                            <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                                 <figure class="highcharts-figure" onclick="return false;">
                                     <div id="comm-1"></div> 
                                     <!-- JS file link -->
@@ -294,7 +294,7 @@
             <div class="mx-auto my-1 w-3/4">
                 <!-- Pie -->
                 <div id="pie"  style="display: none" class="flex-col items-center w-full my-3">                
-                    <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+                    <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                         <figure class="highcharts-figure" onclick="return false;">
                             <div id="pie-cont"></div>
                             <!-- JS file link -->
@@ -305,7 +305,7 @@
 
                 <!-- Stack -->
                 <div id="stack"  style="display: none" class="flex-col items-center w-full my-3">                
-                    <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+                    <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                         <figure class="highcharts-figure" onclick="return false;">
                             <div id="stack-cont"></div>
                             <!-- JS file link -->
@@ -318,7 +318,7 @@
 
                 <!-- Contributor -->
                 <div id="contributor-single"  style="display: none" class="flex-col items-center w-full my-3">                
-                    <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+                    <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                         <figure class="highcharts-figure" onclick="return false;">
                             <div id="cont-0"></div>
                             <!-- JS file link -->
@@ -329,7 +329,7 @@
         
                 <!-- Commit -->
                 <div id="commit-single" style="display: none" class="flex-col items-center my-3 w-full">
-                    <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+                    <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                         <figure class="highcharts-figure" onclick="return false;">
                             <div id="comm-0"></div> 
                             <!-- JS file link -->

--- a/public/js/comparison_graphs.js
+++ b/public/js/comparison_graphs.js
@@ -240,7 +240,7 @@ function addGraph() {
     div.innerHTML = `
     <div class="mx-auto my-3 w-full"> 
         <div id="contributor-`+ String(numRows) + `" style="display: none" class="flex-col items-center w-full my-3">                
-            <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+            <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                 <figure class="highcharts-figure" onclick="return false;">
                     <div id="cont-`+ String(numRows) + `"></div>
                     <!-- JS file link -->
@@ -250,7 +250,7 @@ function addGraph() {
         </div>
     
         <div id="commit-`+ String(numRows) + `" style="display: none" class="flex-col items-center my-3 w-full">
-            <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+            <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                 <figure class="highcharts-figure" onclick="return false;">
                     <div id="comm-`+ String(numRows) + `"></div> 
                     <!-- JS file link -->

--- a/public/quick_facts.html
+++ b/public/quick_facts.html
@@ -131,7 +131,7 @@
                 </div>
                 <!-- Graph 1 Percent Area -->
                 <div class="flex flex-col w-1/2 h-full mr-16">  
-                    <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+                    <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                         <figure class="highcharts-figure" onclick="return false;">
                             <div id="percent"></div>
                             <script src="https://blacklabel.github.io/grouped_categories/grouped-categories.js"></script>    
@@ -176,7 +176,7 @@
                     </div>
 
                     <div id="cont" alt="Graph1" style="display: show" class="flex-col items-center w-full h-full">                
-                        <a href="#" class="hover:opacity-75 my-4 md:w-3/3">
+                        <a href="#!" class="hover:opacity-75 my-4 md:w-3/3">
                             <figure class="highcharts-figure" onclick="return false;">
                                 <div id="cont-1"></div>
                                 <!-- JS file link -->
@@ -190,7 +190,7 @@
                     </div>
 
                     <div id="comm" alt="Graph1" style="display: none" class="flex-col items-center w-full h-full">
-                        <a href="#" class="hover:opacity-75 my-4 md:w-3/3">
+                        <a href="#!" class="hover:opacity-75 my-4 md:w-3/3">
                             <figure class="highcharts-figure" onclick="return false;">
                                 <div id="comm-1"></div> 
                                 <!-- JS file link -->
@@ -208,7 +208,7 @@
                 </div>
                 <!-- Graph 3 Dumbbell -->
                 <div class="flex flex-col w-1/2 h-full mr-16">
-                    <a href="#" class="px-6 hover:opacity-75 my-4 md:w-3/3">
+                    <a href="#!" class="px-6 hover:opacity-75 my-4 md:w-3/3">
                         <figure class="highcharts-figure" onclick="return false;">
                             <div id="dumbbell"></div>
                             <script src="https://blacklabel.github.io/grouped_categories/grouped-categories.js"></script>    
@@ -244,7 +244,7 @@
                     <div class="absolute z-0 blob6">
                         <img src="img/NumberBlob4.png" alt="Blob"/>
                     </div>
-                    <a href="#" class="px-3 hover:opacity-75 my-2 md:w-3/4">
+                    <a href="#!" class="px-3 hover:opacity-75 my-2 md:w-3/4">
                         <figure class="highcharts-figure" onclick="return false;">
                             <div id="pie-cont"></div>
                             <!-- JS file link -->


### PR DESCRIPTION
**Problem**
Clicking the export button on the Highcharts figures sends the user back to the top of the page. 
This is caused by the `<a href="#" />` wrappers around the figures, which makes clicking a navigation event, and scrolling to the top part of its default behavior.

**Solution**
The simple workaround is to replace the wrapper with `<a href="#!" />`. This asks the browser to navigate to a fragment of the page with ID "!" which doesn't exist. 