### PR TITLE
Gallery page minor updates

### DIFF
--- a/public/comparison.html
+++ b/public/comparison.html
@@ -18,7 +18,7 @@
     <link rel="icon" type="image/jpg" href="img/CensusLogo2.png">
 
     <style>
-        li#xomparison  { 
+        li#comparison  { 
             color: #f4f4f4; 
             font-weight: bold;
         } 

--- a/public/css/subpage.css
+++ b/public/css/subpage.css
@@ -267,6 +267,10 @@ td, th {
     margin: auto 0;
 }
 
+.text-size-subtitle-container {
+    width: 85%;
+}
+
 /* Loading in Images */
 
 .reveal{

--- a/public/gallery.html
+++ b/public/gallery.html
@@ -91,7 +91,9 @@
         </div>
 
         <!-- Graph 1 All line graph -->
-        <h1 id="line-title" class="text-primary lato-bold text-size-subtitle pt-40 pl-40 pr-40">% Women over Time</h1>
+        <div class="text-size-subtitle-container">
+            <h1 id="line-title" class="text-primary lato-bold text-size-subtitle pt-40 pl-40 pr-40">% Women over Time</h1>
+        </div>
         <p class = "py-4 text-gray-400 text-size-xs lato-regular pl-48 pr-48">
             The lines demonstrate the change in the number of women in open source projects with the change of time from 2008 to 2019. (The scale is not on 0-100%.) <br>
             Genders in the dataset are <a class="text-green-600" href="./index.html#gender-inference">inferred</a> based on name and cultural background with the tool NamSor, limited by the tool's binary gender inference capability.
@@ -121,7 +123,9 @@
         </div>
 
         <!-- Graph 2 All bar graphs for women contributors -->
-        <h1 id="women-bar-title" class="text-primary lato-bold text-size-subtitle pt-40 pl-40 pr-40"># Contributors by inferred gender</h1>
+        <div class="text-size-subtitle-container">
+            <h1 id="women-bar-title" class="text-primary lato-bold text-size-subtitle pt-40 pl-40 pr-40"># Contributors by inferred gender</h1>
+        </div>
         <p class = "py-4 text-gray-400 text-size-xs lato-regular pl-48 pr-48">
             The bar graphs demonstrate the change in the ratio of women out of all binary-gendered contributors in open source projects with the change of time from 2008 to 2019. (The scale is different for each graph) <br>
             Genders in the dataset are <a class="text-green-600" href="./index.html#gender-inference">inferred</a> based on name and cultural background with the tool NamSor, limited by the tool's binary gender inference capability.

--- a/public/gallery.html
+++ b/public/gallery.html
@@ -18,7 +18,7 @@
     <link rel="icon" type="image/jpg" href="img/CensusLogo2.png">
 
     <style>
-        li#xomparison  { 
+        li#gallery  { 
             color: #f4f4f4; 
             font-weight: bold;
         } 
@@ -63,7 +63,7 @@
         });
     </script> 
 
-    <body id="comparison w-full h-full" onload="loadGraphs()">
+    <body id="gallery w-full h-full" onload="loadGraphs()">
 
     <div class="bg-white font-family-karla w-full h-full">
         <!-- Top Bar Nav -->


### PR DESCRIPTION
### Fixed Issues
- Gallery page has horizontal overflow
    - The effect of using "text-size-subtitle" on the section titles (scales the title horizontally by +15%)
    - Fixed by limiting width
- Fixed typos in Gallery and Comparison pages' IDs.